### PR TITLE
Change health check to test if a single bucket exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+# IDE-specific files (Rider)
+.idea
+
 # Visual Studio 2015 cache/options directory
 .vs/
 .vscode/

--- a/src/Minio.AspNetCore.HealthChecks/MinioHealthCheck.cs
+++ b/src/Minio.AspNetCore.HealthChecks/MinioHealthCheck.cs
@@ -1,14 +1,17 @@
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Minio.DataModel.Args;
 
 namespace Minio.AspNetCore.HealthChecks
 {
   public class MinioHealthCheck : IHealthCheck
   {
     private readonly MinioClient minioClient;
+    private readonly string bucket;
 
-    public MinioHealthCheck(MinioClient minioClient)
+    public MinioHealthCheck(MinioClient minioClient, string bucket)
     {
       this.minioClient = minioClient;
+      this.bucket = bucket;
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(
@@ -17,7 +20,8 @@ namespace Minio.AspNetCore.HealthChecks
     {
       try
       {
-        await minioClient.ListBucketsAsync(cancellationToken).ConfigureAwait(false);
+        var bucketExistsArgs = new BucketExistsArgs().WithBucket(bucket);
+        await minioClient.BucketExistsAsync(bucketExistsArgs, cancellationToken).ConfigureAwait(false);
 
         return HealthCheckResult.Healthy();
       }

--- a/src/Minio.AspNetCore.HealthChecks/MinioHealthChecksExtensions.cs
+++ b/src/Minio.AspNetCore.HealthChecks/MinioHealthChecksExtensions.cs
@@ -5,10 +5,16 @@ namespace Minio.AspNetCore.HealthChecks
 {
   public static class MinioHealthChecksExtensions
   {
+    /// <summary>
+    /// Adds a health check for MinIO to the specified <see cref="builder"/>.
+    /// The health check tests if a bucket with the specified <see cref="bucket"/> name exists.
+    /// Whether the bucket actually exists doesn't matter - the health check is successful if the call to MinIO doesn't throw.
+    /// </summary>
     public static IHealthChecksBuilder AddMinio(
       this IHealthChecksBuilder builder,
       Func<IServiceProvider, MinioClient> factory,
       string name = "minio",
+      string bucket = "health",
       HealthStatus? failureStatus = null,
       IEnumerable<string>? tags = null,
       TimeSpan? timeout = null)
@@ -17,10 +23,18 @@ namespace Minio.AspNetCore.HealthChecks
       {
         throw new ArgumentNullException(nameof(builder));
       }
+      if (string.IsNullOrWhiteSpace(name))
+      {
+        throw new ArgumentException("Health check name should not be null or whitespace.", nameof(name));
+      }
+      if (string.IsNullOrWhiteSpace(bucket))
+      {
+        throw new ArgumentException("Health check bucket should not be null or whitespace.", nameof(bucket));
+      }
 
       return builder.Add(new HealthCheckRegistration(
         name,
-        sp => new MinioHealthCheck(factory.Invoke(sp)),
+        sp => new MinioHealthCheck(factory.Invoke(sp), bucket),
         failureStatus,
         tags,
         timeout));


### PR DESCRIPTION
Details in #71 

Implementation contains a breaking change - a new `bucket` parameter to the `AddMinio` extension method. If clients do not use named parameters and rely on parameter ordering they may have compilation errors in some cases. To avoid that the health bucket name could be changed not to be customizable but to have a static name. Alternatively, the parameter could be moved at the last position which kind of violates health check parameters order consistency. Let me know which way you prefer.

cc @sergeyshaykhullin 